### PR TITLE
README更新

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+deps
+_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM hexpm/elixir:1.13.1-erlang-24.2.1-debian-bullseye-20210902-slim
+
+RUN apt-get update && \
+    apt-get install --yes build-essential inotify-tools postgresql-client && \
+    apt-get clean
+
+RUN mix local.hex --force && \
+  mix archive.install hex phx_new --force && \
+  mix local.rebar --force
+
+ADD . /app
+WORKDIR /app
+EXPOSE 4000
+
+CMD ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ローカルマシン上で直接、サンプルコードを動かす場合の手順です。
 
+macOS Catalina(10.15.7)、macOS Monterey(12.2)で動作することを確認しています。
+
 ### 必要なもの
 
 事前に必要なものは次の2点です。
@@ -55,6 +57,13 @@ $ mix test
 ローカルマシンに、インストールした[Docker](https://www.docker.com/)上で「すべて」を動かす手順です。
 
 ここで言う「すべて」とは、Elixir、Phoenix、PostgreSQLを指します。
+
+以下の環境で動作することを確認しています。
+
+- macOS Monterey(12.2)、macOS Catalina(10.15.7)
+  - Docker Desktop 4.4.2
+- Windows 11 Home(バージョン 21H2, OS ビルド 22000.434)
+  - Docker Desktop 4.4.4
 
 ### 必要なもの
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,93 @@
 # Realworld
 
-To start your Phoenix server:
+## Run on local machine
 
-  * Install dependencies with `mix deps.get`
-  * Create and migrate your database with `mix ecto.setup`
-  * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
+### Requirements
 
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+- Elixir
+- PostgreSQL
+
+Please refer to [Installation](https://hexdocs.pm/phoenix/installation.html#content).
+
+### Run
+
+```
+$ mix setup
+$ mix phx.server
+```
+
+Visit: http://localhost:4000/articles
+
+### Test
+
+```
+$ mix test
+```
+
+
+## Run on [Docker](https://www.docker.com/)
+
+### Requirements
+
+- [Docker](https://www.docker.com/)
+
+### Configuration
+
+#### config/dev.exs
+
+```diff
+ config :realworld, Realworld.Repo,
+   username: "postgres",
+   password: "postgres",
+-  hostname: "localhost",
++  hostname: "db",
+   database: "realworld_dev",
+   show_sensitive_data_on_connection_error: true,
+   pool_size: 10
+
+ config :realworld, RealworldWeb.Endpoint,
+   # Binding to loopback ipv4 address prevents access from other machines.
+   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
+-  http: [ip: {127, 0, 0, 1}, port: 4000],
++  http: [ip: {0, 0, 0, 0}, port: 4000],
+   check_origin: false,
+   code_reloader: true,
+   debug_errors: true,
+```
+
+#### config/test.exs
+
+```diff
+ config :realworld, Realworld.Repo,
+   username: "postgres",
+   password: "postgres",
+-  hostname: "localhost",
++  hostname: "db",
+   database: "realworld_test#{System.get_env("MIX_TEST_PARTITION")}",
+   pool: Ecto.Adapters.SQL.Sandbox,
+   pool_size: 10
+```
+
+### Run
+
+```
+$ docker-compose build
+$ docker-compose up
+```
+
+Visit: http://localhost:4000/articles
+
+### Test
+
+```
+$ docker-compose run --rm web mix test
+```
+
+### Stop
+
+```
+$ docker-compose stop
+```
 
 Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
 
@@ -17,3 +98,4 @@ Ready to run in production? Please [check our deployment guides](https://hexdocs
   * Docs: https://hexdocs.pm/phoenix
   * Forum: https://elixirforum.com/c/phoenix-forum
   * Source: https://github.com/phoenixframework/phoenix
+  * [elixirjp.slack.com](https://join.slack.com/t/elixirjp/shared_invite/zt-ae8m5bad-WW69GH1w4iuafm1tKNgd~w): Hope you'll join us!

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@
 
 事前に必要なものは次の2点です。
 
-- Elixir 1.12 or later
-- PostgreSQL
+- Elixir 1.13 or later
+- Erlang 24.0 or later
+- PostgreSQL 13 or later
 
 詳しくは、[WEB+DB PRESS Vol.127](https://gihyo.jp/magazine/wdpress/archive/2022/vol127)の特集「Elixirによる高速なWeb開発！　作って学ぶPhoenix」をご参照ください。
 

--- a/README.md
+++ b/README.md
@@ -1,83 +1,89 @@
 # Realworld
 
-## Run on local machine
+これは[WEB+DB PRESS Vol.127](https://gihyo.jp/magazine/wdpress/archive/2022/vol127)の特集「Elixirによる高速なWeb開発！　作って学ぶPhoenix」のサンプルコードです。
 
-### Requirements
+![表紙画像](https://user-images.githubusercontent.com/4215723/152686942-be6d5ffd-fe7b-4a0d-9e38-c264705c182b.jpeg)
 
-- Elixir
+## ローカルマシンで動かす
+
+ローカルマシン上で直接、サンプルコードを動かす場合の手順です。
+
+### 必要なもの
+
+事前に必要なものは次の2点です。
+
+- Elixir 1.12 or later
 - PostgreSQL
 
-Please refer to [Installation](https://hexdocs.pm/phoenix/installation.html#content).
+詳しくは、[WEB+DB PRESS Vol.127](https://gihyo.jp/magazine/wdpress/archive/2022/vol127)の特集「Elixirによる高速なWeb開発！　作って学ぶPhoenix」をご参照ください。
+
+
+### 環境構築
+
+環境構築は次の通りです。
+
+```
+$ git clone https://github.com/elixirjp-slack-com/realworld.git
+$ cd realworld
+$ mix setup
+```
 
 ### Run
 
+実行は、次のコマンドにより行います。
+
 ```
-$ mix setup
 $ mix phx.server
 ```
 
-Visit: http://localhost:4000/articles
+http://localhost:4000/articles
+にアクセスをしてください。
 
-### Test
+### テスト
+
+テストは、次のコマンドにより実施できます。
 
 ```
 $ mix test
 ```
 
+---
 
-## Run on [Docker](https://www.docker.com/)
+## [Docker](https://www.docker.com/)上で動かす
 
-### Requirements
+ローカルマシンに、インストールした[Docker](https://www.docker.com/)上で「すべて」を動かす手順です。
 
-- [Docker](https://www.docker.com/)
+ここで言う「すべて」とは、Elixir、Phoenix、PostgreSQLを指します。
 
-### Configuration
+### 必要なもの
 
-#### config/dev.exs
+事前に必要なものは、[Docker](https://www.docker.com/)のみです。
 
-```diff
- config :realworld, Realworld.Repo,
-   username: "postgres",
-   password: "postgres",
--  hostname: "localhost",
-+  hostname: "db",
-   database: "realworld_dev",
-   show_sensitive_data_on_connection_error: true,
-   pool_size: 10
 
- config :realworld, RealworldWeb.Endpoint,
-   # Binding to loopback ipv4 address prevents access from other machines.
-   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
--  http: [ip: {127, 0, 0, 1}, port: 4000],
-+  http: [ip: {0, 0, 0, 0}, port: 4000],
-   check_origin: false,
-   code_reloader: true,
-   debug_errors: true,
+### 環境構築
+
+環境構築は次の通りです。
+
 ```
-
-#### config/test.exs
-
-```diff
- config :realworld, Realworld.Repo,
-   username: "postgres",
-   password: "postgres",
--  hostname: "localhost",
-+  hostname: "db",
-   database: "realworld_test#{System.get_env("MIX_TEST_PARTITION")}",
-   pool: Ecto.Adapters.SQL.Sandbox,
-   pool_size: 10
+$ git clone https://github.com/elixirjp-slack-com/realworld.git
+$ cd realworld
+$ docker-compose build --no-cache
 ```
 
 ### Run
 
+実行は、次のコマンドにより行います。
+
 ```
-$ docker-compose build
-$ docker-compose up
+$ docker-compose up -d
 ```
 
-Visit: http://localhost:4000/articles
+http://localhost:4000/articles
+にアクセスをしてください。
 
-### Test
+### テスト
+
+テストは、次のコマンドにより実施できます。
 
 ```
 $ docker-compose run --rm web mix test
@@ -85,17 +91,30 @@ $ docker-compose run --rm web mix test
 
 ### Stop
 
+次のコマンドで停止できます。
+
 ```
 $ docker-compose stop
 ```
 
-Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
+---
 
-## Learn more
+## 本番運用したい
+
+[deployment guides](https://hexdocs.pm/phoenix/deployment.html)をご参照ください。
+
+## もっと学びたい
 
   * Official website: https://www.phoenixframework.org/
   * Guides: https://hexdocs.pm/phoenix/overview.html
   * Docs: https://hexdocs.pm/phoenix
   * Forum: https://elixirforum.com/c/phoenix-forum
   * Source: https://github.com/phoenixframework/phoenix
-  * [elixirjp.slack.com](https://join.slack.com/t/elixirjp/shared_invite/zt-ae8m5bad-WW69GH1w4iuafm1tKNgd~w): Hope you'll join us!
+
+## [elixirjp.slack.com](https://join.slack.com/t/elixirjp/shared_invite/zt-ae8m5bad-WW69GH1w4iuafm1tKNgd~w)
+
+[elixirjp.slack.com](https://join.slack.com/t/elixirjp/shared_invite/zt-ae8m5bad-WW69GH1w4iuafm1tKNgd~w)に、執筆陣はおります。
+
+ぜひ飛び込んできてください。
+
+あなたの参加を熱烈歓迎いたします:tada:

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,7 +4,7 @@ import Config
 config :realworld, Realworld.Repo,
   username: "postgres",
   password: "postgres",
-  hostname: "localhost",
+  hostname: System.get_env("WEB_DB_PRESS_VOL_127_DB_HOST", "localhost"),
   database: "realworld_dev",
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
@@ -18,7 +18,7 @@ config :realworld, Realworld.Repo,
 config :realworld, RealworldWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  http: [ip: {0, 0, 0, 0}, port: 4000],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,7 +11,7 @@ config :bcrypt_elixir, :log_rounds, 1
 config :realworld, Realworld.Repo,
   username: "postgres",
   password: "postgres",
-  hostname: "localhost",
+  hostname: System.get_env("WEB_DB_PRESS_VOL_127_DB_HOST", "localhost"),
   database: "realworld_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - '4000:4000'
     volumes:
       - .:/app
+    environment:
+      WEB_DB_PRESS_VOL_127_DB_HOST: db
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,14 @@
 version: '3'
 services:
+  web:
+    build: .
+    ports:
+      - '4000:4000'
+    volumes:
+      - .:/app
+    depends_on:
+      - db
+
   db:
     image: postgres:13-alpine
     environment:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Docker entrypoint script.
+
+# Wait until Postgres is ready
+echo "Testing if Postgres is accepting connections."
+while ! pg_isready -q -h db -p 5432 -U postgres
+do
+  echo "$(date) - waiting for database to start"
+  sleep 2
+done
+
+mix setup
+mix deps.compile
+
+exec mix phx.server


### PR DESCRIPTION
ふつう？ に[Installation](https://hexdocs.pm/phoenix/installation.html#content)から進めて、ローカルマシンでイゴかす手順とDockerのみでイゴかす手順をかきました
Dockerのみでイゴかす変更について補足します。

- `docker-compose up`でRunできるようにしてみました
- Dockerfileに`build-essential`をいれたのは、`Bcrypt`のビルドで`make`が必要だったからです
- もっと洗練、厳選できるところがあるかもしれませんがとりあえずmacOS CatalinaとWindows 11でイゴいた内容でプルリクを作りました
- 欠点は、`config/`以下のファイルを変更しないといけないことです